### PR TITLE
Add graphql url to the incoming event

### DIFF
--- a/types.go
+++ b/types.go
@@ -72,6 +72,7 @@ type EventIncoming struct {
 		Logs         string `edn:"logs"`
 		Transactions string `edn:"transactions"`
 		Query        string `edn:"query"`
+		Graphql      string `edn:"graphql"`
 	} `edn:"urls"`
 	Token string `edn:"token"`
 }


### PR DESCRIPTION
This PR exposes the graphql url to the incoming event so it can be used to run GraphQL from the skill.

Needed for:

- https://github.com/atomist-skills/goal-evaluation-skill/pull/53