### PR TITLE
Add sync request to types

### DIFF
--- a/handle.go
+++ b/handle.go
@@ -106,6 +106,18 @@ func createHttpHandler(handlers Handlers) func(http.ResponseWriter, *http.Reques
 			}
 			w.WriteHeader(201)
 
+			if req.Event.Type == "sync-request" {
+				r := struct {
+					Result interface{} `edn:"result"`
+				}{
+					Result: status.SyncRequest,
+				}
+				b, err := edn.Marshal(r)
+				if err != nil {
+					Log.Panicf("Failed to edn result in sync-request: %s", err)
+				}
+				w.Write(b)
+			}
 		} else {
 			err = sendStatus(ctx, req, Status{
 				State:  Failed,

--- a/name.go
+++ b/name.go
@@ -34,6 +34,8 @@ func nameFromEvent(event EventIncoming) string {
 		return event.Context.AsyncQueryResult.Name
 	case "event":
 		return event.Context.Event.Name
+	case "sync-request":
+		return event.Context.SyncRequest.Name
 	}
 	return ""
 }

--- a/types.go
+++ b/types.go
@@ -100,8 +100,9 @@ const (
 )
 
 type Status struct {
-	State  edn.Keyword `edn:"state"`
-	Reason string      `edn:"reason,omitempty"`
+	State       edn.Keyword `edn:"state"`
+	Reason      string      `edn:"reason,omitempty"`
+	SyncRequest interface{} `edn:"sync-request,omitempty"`
 }
 
 type RequestContext struct {

--- a/types.go
+++ b/types.go
@@ -40,12 +40,13 @@ type Skill struct {
 }
 
 type EventIncoming struct {
-	ExecutionId string      `edn:"execution-id"`
-	Skill       Skill       `edn:"skill"`
-	Type        edn.Keyword `edn:"type"`
-	WorkspaceId string      `edn:"workspace-id"`
-	Environment string      `edn:"environment,omitempty"`
-	Context     struct {
+	ExecutionId  string      `edn:"execution-id"`
+	Skill        Skill       `edn:"skill"`
+	Type         edn.Keyword `edn:"type"`
+	WorkspaceId  string      `edn:"workspace-id"`
+	Environment  string      `edn:"environment,omitempty"`
+	Organization string      `edn:"organization,omitempty"`
+	Context      struct {
 		Subscription struct {
 			Name          string             `edn:"name"`
 			Configuration Configuration      `edn:"configuration"`
@@ -70,7 +71,7 @@ type EventIncoming struct {
 			Name          string                         `edn:"name"`
 			Configuration Configuration                  `edn:"configuration"`
 			Metadata      map[edn.Keyword]edn.RawMessage `edn:"metadata"`
-		} `end:"sync-request"`
+		} `edn:"sync-request"`
 		AsyncQueryResult struct {
 			Name     string                         `edn:"name"`
 			Metadata string                         `edn:"metadata"`

--- a/types.go
+++ b/types.go
@@ -66,6 +66,11 @@ type EventIncoming struct {
 				Tags    []ParameterValue  `edn:"tags"`
 			} `edn:"request"`
 		} `edn:"webhook"`
+		SyncRequest struct {
+			Name          string                         `edn:"name"`
+			Configuration Configuration                  `edn:"configuration"`
+			Metadata      map[edn.Keyword]edn.RawMessage `edn:"metadata"`
+		} `end:"sync-request"`
 		AsyncQueryResult struct {
 			Name     string                         `edn:"name"`
 			Metadata string                         `edn:"metadata"`


### PR DESCRIPTION
This PR extends the context of the `EventIncoming` struct with the new `SyncRequest` field. It should allow us to get the sync request's name as the handler's name in the `goal-evaluation-skill`.

This way, the Scout CLI will issue a sync query with name `evaluate_policy_sync_request` and whose metadata contains the purls and whether to transact the results into Datomic.