### PR TITLE
Don't log, transact or send status to the platform

### DIFF
--- a/log.go
+++ b/log.go
@@ -76,6 +76,10 @@ func createLogger(ctx context.Context, event EventIncoming) Logger {
 	logger := Logger{}
 
 	var doLog = func(msg string, level edn.Keyword) {
+		// Don't send logs when evaluating policies locally
+		if os.Getenv("SCOUT_LOCAL_POLICY_EVALUATION") == "true" {
+			return
+		}
 		bs, err := edn.MarshalPPrint(internal.LogBody{Logs: []internal.LogEntry{{
 			Timestamp: time.Now().UTC().Format("2006-01-02T15:04:05.999Z"),
 			Level:     level,

--- a/status.go
+++ b/status.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"net/http"
+	"os"
 
 	"github.com/atomist-skills/go-skill/internal"
 
@@ -41,6 +42,10 @@ func NewFailedStatus(reason string) Status {
 }
 
 func sendStatus(ctx context.Context, req RequestContext, status Status) error {
+	// Don't send the status when evaluating policies locally
+	if os.Getenv("SCOUT_LOCAL_POLICY_EVALUATION") == "true" {
+		return nil
+	}
 	bs, err := edn.MarshalPPrint(internal.StatusBody{
 		Status: status,
 	}, nil)

--- a/transact.go
+++ b/transact.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"reflect"
 	"strings"
 
@@ -185,6 +186,11 @@ func createMessageSender(ctx context.Context, req RequestContext) messageSender 
 	messageSender := messageSender{}
 
 	messageSender.TransactOrdered = func(entities interface{}, orderingKey string) error {
+		// Don't transact when evaluating policies locally
+		if os.Getenv("SCOUT_LOCAL_POLICY_EVALUATION") == "true" {
+			return nil
+		}
+
 		var entityArray []interface{}
 		rt := reflect.TypeOf(entities)
 		switch rt.Kind() {


### PR DESCRIPTION
Don't log, transact, or send status to the platform when running policies locally.