### PR TITLE
add local eval fixedQueryResult test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hasura/go-graphql-client v0.9.3
 	github.com/mitchellh/hashstructure/v2 v2.0.1
 	github.com/sirupsen/logrus v1.9.0
+	github.com/stretchr/testify v1.8.1
 	golang.org/x/oauth2 v0.13.0
 	google.golang.org/api v0.147.0
 	olympos.io/encoding/edn v0.0.0-20201019073823-d3554ca0b0a3
@@ -20,6 +21,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v1.1.2 // indirect
 	cloud.google.com/go/longrunning v0.5.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
@@ -27,6 +29,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.1 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
 	github.com/klauspost/compress v1.10.3 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.14.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
@@ -40,5 +43,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231009173412-8bfb1ae86b6c // indirect
 	google.golang.org/grpc v1.58.2 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	nhooyr.io/websocket v1.8.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -222,6 +222,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=

--- a/policy/policy_handler/legacy/image_packages_by_digest.go
+++ b/policy/policy_handler/legacy/image_packages_by_digest.go
@@ -1,0 +1,156 @@
+package legacy
+
+import (
+	"context"
+	"github.com/atomist-skills/go-skill"
+	"github.com/atomist-skills/go-skill/policy/data"
+)
+
+// Versions of scout-cli-plugin created before the introduction of fixedQueryResults
+// directly passed a []Package object in the metadata for local evaluation.
+// This was then supplemented by a synchronous GraphQL call to load vulnerability data,
+// so we mock the entire process to support these older versions.
+// TODO remove this whole system when no longer used
+
+const (
+	ImagePackagesByDigestQueryName    = "image-packages-by-digest"
+	vulnerabilitiesByPackageQueryName = "vulnerabilities-by-package"
+
+	// language=graphql
+	vulnerabilitiesByPackageQuery = `
+	query ($context: Context!, $packageUrls: [String!]!) {
+		vulnerabilitiesByPackage(context: $context, packageUrls: $packageUrls) {
+			purl
+			vulnerabilities {
+			cvss {
+				severity
+				score
+			}
+			fixedBy
+			publishedAt
+			source
+			sourceId
+			updatedAt
+			url
+			vulnerableRange
+			}
+		}
+	}`
+)
+
+type (
+	Package struct {
+		Licenses  []string `edn:"licenses,omitempty"` // only needed for the license policy evaluation
+		Name      string   `edn:"name"`
+		Namespace string   `edn:"namespace"`
+		Version   string   `edn:"version"`
+		Purl      string   `edn:"purl"`
+		Type      string   `edn:"type"`
+	}
+
+	ImagePackagesByDigestResponse struct {
+		ImagePackagesByDigest *ImagePackagesByDigest `json:"imagePackagesByDigest" edn:"imagePackagesByDigest"`
+	}
+
+	ImagePackagesByDigest struct {
+		ImagePackages ImagePackages `json:"imagePackages" edn:"imagePackages"`
+	}
+
+	ImagePackages struct {
+		Packages []Packages `json:"packages" edn:"packages"`
+	}
+
+	Packages struct {
+		Package PackageWithLicenses `json:"package" edn:"package"`
+	}
+
+	PackageWithLicenses struct {
+		Licenses        []string        `json:"licenses" edn:"licenses"`
+		Name            string          `json:"name" edn:"name"`
+		Namespace       *string         `json:"namespace" edn:"namespace"`
+		Version         string          `json:"version" edn:"version"`
+		Purl            string          `json:"purl" edn:"purl"`
+		Type            string          `json:"type" edn:"type"`
+		Vulnerabilities []Vulnerability `json:"vulnerabilities" edn:"vulnerabilities"`
+	}
+
+	Vulnerability struct {
+		Cvss            Cvss    `json:"cvss"`
+		FixedBy         *string `json:"fixedBy"`
+		PublishedAt     string  `json:"publishedAt"`
+		Source          string  `json:"source"`
+		SourceID        string  `json:"sourceId"`
+		UpdatedAt       string  `json:"updatedAt"`
+		URL             *string `json:"url"`
+		VulnerableRange string  `json:"vulnerableRange"`
+	}
+
+	Cvss struct {
+		Severity *string  `json:"severity"`
+		Score    *float32 `json:"score"`
+	}
+
+	VulnerabilitiesByPackageResponse struct {
+		VulnerabilitiesByPackage []VulnerabilitiesByPackage `json:"vulnerabilitiesByPackage"`
+	}
+
+	VulnerabilitiesByPackage struct {
+		Purl            string          `json:"purl"`
+		Vulnerabilities []Vulnerability `json:"vulnerabilities"`
+	}
+)
+
+func MockImagePackagesByDigest(ctx context.Context, req skill.RequestContext, sbomPkgs []Package) (ImagePackagesByDigestResponse, error) {
+	// separated for testing
+	ds, err := data.NewSyncGraphqlDataSource(ctx, req)
+	if err != nil {
+		return ImagePackagesByDigestResponse{}, err
+	}
+
+	return mockImagePackagesByDigest(ctx, req, sbomPkgs, ds)
+}
+
+func mockImagePackagesByDigest(ctx context.Context, req skill.RequestContext, sbomPkgs []Package, ds data.DataSource) (ImagePackagesByDigestResponse, error) {
+	purls := []string{}
+	for _, p := range sbomPkgs {
+		purls = append(purls, p.Purl)
+	}
+
+	var vulnsResponse VulnerabilitiesByPackageResponse
+	_, err := ds.Query(ctx, vulnerabilitiesByPackageQueryName, vulnerabilitiesByPackageQuery, map[string]interface{}{
+		"context":     data.GqlContext(req),
+		"packageUrls": purls,
+	}, &vulnsResponse)
+	if err != nil {
+		return ImagePackagesByDigestResponse{}, err
+	}
+
+	vulns := map[string][]Vulnerability{}
+	for _, v := range vulnsResponse.VulnerabilitiesByPackage {
+		vulns[v.Purl] = v.Vulnerabilities
+	}
+
+	pkgs := []Packages{}
+	for _, a := range sbomPkgs {
+		ns := a.Namespace
+		pkgs = append(pkgs, Packages{
+			Package: PackageWithLicenses{
+				Licenses:        a.Licenses,
+				Name:            a.Name,
+				Namespace:       &ns,
+				Version:         a.Version,
+				Purl:            a.Purl,
+				Type:            a.Type,
+				Vulnerabilities: vulns[a.Purl],
+			},
+		})
+	}
+
+	return ImagePackagesByDigestResponse{
+		ImagePackagesByDigest: &ImagePackagesByDigest{
+			ImagePackages: ImagePackages{
+				Packages: pkgs,
+			},
+		},
+	}, nil
+}

--- a/policy/policy_handler/legacy/image_packages_by_digest_test.go
+++ b/policy/policy_handler/legacy/image_packages_by_digest_test.go
@@ -1,0 +1,110 @@
+package legacy
+
+import (
+	"context"
+	"github.com/atomist-skills/go-skill"
+	"github.com/atomist-skills/go-skill/internal/test_util"
+	"github.com/atomist-skills/go-skill/policy/data"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type MockDs struct {
+	t *testing.T
+}
+
+func (ds MockDs) Query(ctx context.Context, queryName string, query string, variables map[string]interface{}, output interface{}) (*data.QueryResponse, error) {
+	assert.Equal(ds.t, queryName, vulnerabilitiesByPackageQueryName)
+	assert.Equal(ds.t, query, vulnerabilitiesByPackageQuery)
+
+	r := output.(*VulnerabilitiesByPackageResponse)
+	r.VulnerabilitiesByPackage = []VulnerabilitiesByPackage{
+		{
+			Purl: "pkg:deb/ubuntu/libpcre3@2:8.39-12ubuntu0.1?arch=amd64&upstream=pcre3&distro=ubuntu-20.04",
+			Vulnerabilities: []Vulnerability{{
+				Cvss: Cvss{
+					Severity: test_util.Pointer("HIGH"),
+					Score:    test_util.Pointer(float32(7.5)),
+				},
+				FixedBy:         nil,
+				PublishedAt:     "2017-07-10T11:29:00Z",
+				Source:          "nist",
+				SourceID:        "CVE-2017-11164",
+				UpdatedAt:       "2023-04-12T11:15:00Z", // 2006-01-02T15:04:05Z07:00
+				URL:             test_util.Pointer("https://scout.docker.com/v/CVE-2017-11164"),
+				VulnerableRange: ">=0",
+			}},
+		},
+	}
+
+	return &data.QueryResponse{}, nil
+}
+
+func Test_mockImagePackagesByDigest(t *testing.T) {
+	lPkgs := []Package{
+		{
+			Licenses:  []string{"GPL-3.0"},
+			Name:      "libpcre3",
+			Namespace: "pkgNamespace",
+			Version:   "2:8.39-12ubuntu0.1",
+			Purl:      "pkg:deb/ubuntu/libpcre3@2:8.39-12ubuntu0.1?arch=amd64&upstream=pcre3&distro=ubuntu-20.04",
+			Type:      "pkgType",
+		},
+		{
+			Licenses:  []string{"AGPL"},
+			Name:      "coreutils",
+			Namespace: "coreutilsNamespace",
+			Version:   "8.30-3ubuntu2",
+			Purl:      "pkg:deb/ubuntu/coreutils@8.30-3ubuntu2?arch=amd64&distro=ubuntu-20.04",
+			Type:      "coreutilsType",
+		},
+	}
+
+	actual, err := mockImagePackagesByDigest(context.TODO(), skill.RequestContext{}, lPkgs, MockDs{t})
+	assert.NoError(t, err)
+
+	expected := ImagePackagesByDigestResponse{
+		ImagePackagesByDigest: &ImagePackagesByDigest{
+			ImagePackages: ImagePackages{
+				Packages: []Packages{
+					{
+						Package: PackageWithLicenses{
+							Licenses:  []string{"GPL-3.0"},
+							Name:      "libpcre3",
+							Namespace: test_util.Pointer("pkgNamespace"),
+							Version:   "2:8.39-12ubuntu0.1",
+							Purl:      "pkg:deb/ubuntu/libpcre3@2:8.39-12ubuntu0.1?arch=amd64&upstream=pcre3&distro=ubuntu-20.04",
+							Type:      "pkgType",
+							Vulnerabilities: []Vulnerability{{
+								Cvss: Cvss{
+									Severity: test_util.Pointer("HIGH"),
+									Score:    test_util.Pointer(float32(7.5)),
+								},
+								FixedBy:         nil,
+								PublishedAt:     "2017-07-10T11:29:00Z",
+								Source:          "nist",
+								SourceID:        "CVE-2017-11164",
+								UpdatedAt:       "2023-04-12T11:15:00Z", // 2006-01-02T15:04:05Z07:00
+								URL:             test_util.Pointer("https://scout.docker.com/v/CVE-2017-11164"),
+								VulnerableRange: ">=0",
+							}},
+						},
+					},
+					{
+						Package: PackageWithLicenses{
+							Licenses:        []string{"AGPL"},
+							Name:            "coreutils",
+							Namespace:       test_util.Pointer("coreutilsNamespace"),
+							Version:         "8.30-3ubuntu2",
+							Purl:            "pkg:deb/ubuntu/coreutils@8.30-3ubuntu2?arch=amd64&distro=ubuntu-20.04",
+							Type:            "coreutilsType",
+							Vulnerabilities: nil,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, expected, actual)
+}

--- a/policy/policy_handler/local_test.go
+++ b/policy/policy_handler/local_test.go
@@ -1,0 +1,76 @@
+package policy_handler
+
+import (
+	"context"
+	"github.com/atomist-skills/go-skill"
+	"github.com/atomist-skills/go-skill/policy/goals"
+	"github.com/stretchr/testify/assert"
+	"olympos.io/encoding/edn"
+	"testing"
+)
+
+type TestQueryResultFields struct {
+	SomeString     string `edn:"stringField"`
+	SomeOtherField int    `edn:"intField"`
+}
+
+type TestQueryResultInner struct {
+	SomeList []TestQueryResultFields `edn:"myList"`
+}
+type TestQueryResult struct {
+	InnerResult TestQueryResultInner `edn:"inner"`
+}
+
+func Test_buildLocalDataSources_preservesQueryResultsCorrectly(t *testing.T) {
+	const queryName = "test-query"
+	expected := TestQueryResult{
+		InnerResult: TestQueryResultInner{
+			SomeList: []TestQueryResultFields{{
+				SomeString:     "abc",
+				SomeOtherField: 5,
+			}},
+		},
+	}
+	expectedEdn, err := edn.Marshal(expected)
+	if err != nil {
+		t.Fatalf("failed to marshal data: %s", err.Error())
+	}
+
+	srMetaEdn, err := edn.Marshal(SyncRequestMetadata{
+		QueryResults: map[edn.Keyword]edn.RawMessage{
+			queryName: expectedEdn,
+		},
+	})
+
+	ds, err := buildLocalDataSources(
+		context.TODO(),
+		skill.RequestContext{
+			Event: skill.EventIncoming{
+				Context: skill.EventContext{
+					SyncRequest: skill.EventContextSyncRequest{
+						Name:     eventNameLocalEval,
+						Metadata: srMetaEdn,
+					},
+				},
+			},
+		},
+		goals.EvaluationMetadata{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ds) == 0 {
+		t.Fatal("buildLocalDataSources returned no data sources")
+	}
+
+	var actual TestQueryResult
+	r, err := ds[0].Query(context.TODO(), queryName, "", map[string]interface{}{}, &actual)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.AsyncRequestMade {
+		t.Fatal("AsyncRequestMade was set to true, but expected false")
+	}
+
+	assert.Equal(t, expected, actual)
+}

--- a/types.go
+++ b/types.go
@@ -39,51 +39,63 @@ type Skill struct {
 	Version   string `edn:"version"`
 }
 
+type EventContextSubscription struct {
+	Name          string             `edn:"name"`
+	Configuration Configuration      `edn:"configuration"`
+	Result        [][]edn.RawMessage `edn:"result"`
+	Metadata      struct {
+		AfterBasisT  int64  `edn:"after-basis-t"`
+		Tx           int64  `edn:"tx"`
+		ScheduleName string `edn:"schedule-name"`
+	} `edn:"metadata"`
+}
+
+type EventContextWebhook struct {
+	Name          string        `edn:"name"`
+	Configuration Configuration `edn:"configuration"`
+	Request       struct {
+		Url     string            `edn:"url"`
+		Body    string            `edn:"body"`
+		Headers map[string]string `edn:"headers"`
+		Tags    []ParameterValue  `edn:"tags"`
+	} `edn:"request"`
+}
+
+type EventContextSyncRequest struct {
+	Name          string         `edn:"name"`
+	Configuration Configuration  `edn:"configuration"`
+	Metadata      edn.RawMessage `edn:"metadata"`
+}
+
+type EventContextAsyncQueryResult struct {
+	Name          string         `edn:"name"`
+	Configuration Configuration  `edn:"configuration"`
+	Metadata      string         `edn:"metadata"`
+	Result        edn.RawMessage `edn:"result"`
+}
+
+type EventContextEvent struct {
+	Name     string                         `edn:"name"`
+	Metadata map[edn.Keyword]edn.RawMessage `edn:"metadata"`
+}
+
+type EventContext struct {
+	Subscription     EventContextSubscription     `edn:"subscription"`
+	Webhook          EventContextWebhook          `edn:"webhook"`
+	SyncRequest      EventContextSyncRequest      `edn:"sync-request"`
+	AsyncQueryResult EventContextAsyncQueryResult `edn:"query-result"`
+	Event            EventContextEvent            `edn:"event"`
+}
+
 type EventIncoming struct {
-	ExecutionId  string      `edn:"execution-id"`
-	Skill        Skill       `edn:"skill"`
-	Type         edn.Keyword `edn:"type"`
-	WorkspaceId  string      `edn:"workspace-id"`
-	Environment  string      `edn:"environment,omitempty"`
-	Organization string      `edn:"organization,omitempty"`
-	Context      struct {
-		Subscription struct {
-			Name          string             `edn:"name"`
-			Configuration Configuration      `edn:"configuration"`
-			Result        [][]edn.RawMessage `edn:"result"`
-			Metadata      struct {
-				AfterBasisT  int64  `edn:"after-basis-t"`
-				Tx           int64  `edn:"tx"`
-				ScheduleName string `edn:"schedule-name"`
-			} `edn:"metadata"`
-		} `edn:"subscription"`
-		Webhook struct {
-			Name          string        `edn:"name"`
-			Configuration Configuration `edn:"configuration"`
-			Request       struct {
-				Url     string            `edn:"url"`
-				Body    string            `edn:"body"`
-				Headers map[string]string `edn:"headers"`
-				Tags    []ParameterValue  `edn:"tags"`
-			} `edn:"request"`
-		} `edn:"webhook"`
-		SyncRequest struct {
-			Name          string                         `edn:"name"`
-			Configuration Configuration                  `edn:"configuration"`
-			Metadata      map[edn.Keyword]edn.RawMessage `edn:"metadata"`
-		} `edn:"sync-request"`
-		AsyncQueryResult struct {
-			Name          string         `edn:"name"`
-			Configuration Configuration  `edn:"configuration"`
-			Metadata      string         `edn:"metadata"`
-			Result        edn.RawMessage `edn:"result"`
-		} `edn:"query-result"`
-		Event struct {
-			Name     string                         `edn:"name"`
-			Metadata map[edn.Keyword]edn.RawMessage `edn:"metadata"`
-		} `edn:"event"`
-	} `edn:"context"`
-	Urls struct {
+	ExecutionId  string       `edn:"execution-id"`
+	Skill        Skill        `edn:"skill"`
+	Type         edn.Keyword  `edn:"type"`
+	WorkspaceId  string       `edn:"workspace-id"`
+	Environment  string       `edn:"environment,omitempty"`
+	Organization string       `edn:"organization,omitempty"`
+	Context      EventContext `edn:"context"`
+	Urls         struct {
 		Execution    string `edn:"execution"`
 		Logs         string `edn:"logs"`
 		Transactions string `edn:"transactions"`


### PR DESCRIPTION
Handles local evaluation queries by mocking them through fixedQueryResults.

Also includes support for the old []Packages style by converting it to a corresponding ImagePackagesByDigest graphql structure.