### PR TITLE
fix: do not retract from non-existent entities

### DIFF
--- a/policy/goals/entities.go
+++ b/policy/goals/entities.go
@@ -18,13 +18,13 @@ package goals
 
 import "time"
 
-func CreateEntitiesFromResults(results []GoalEvaluationQueryResult, goalDefinition string, goalConfiguration string, image string, storageId string, configHash string, evaluationTs time.Time, tx int64) GoalEvaluationResultEntity {
+func CreateEntitiesFromResults(results []GoalEvaluationQueryResult, goalDefinition string, goalConfiguration string, image string, storageId string, configHash string, evaluationTs time.Time, tx int64, retract bool) GoalEvaluationResultEntity {
 	entity := GoalEvaluationResultEntity{
 		Definition:     goalDefinition,
 		Configuration:  goalConfiguration,
 		Subject:        DockerImageEntity{Digest: image},
-		DeviationCount: RetractionEntity{Retract: true},
-		StorageId:      RetractionEntity{Retract: true},
+		DeviationCount: nil,
+		StorageId:      nil,
 		ConfigHash:     configHash,
 		CreatedAt:      evaluationTs,
 		TransactionCondition: TransactionConditionEntity{
@@ -39,6 +39,9 @@ func CreateEntitiesFromResults(results []GoalEvaluationQueryResult, goalDefiniti
 
 		entity.DeviationCount = deviationCount
 		entity.StorageId = storageId
+	} else if retract {
+		entity.DeviationCount = RetractionEntity{Retract: true}
+		entity.StorageId = RetractionEntity{Retract: true}
 	}
 
 	return entity

--- a/policy/goals/entities_test.go
+++ b/policy/goals/entities_test.go
@@ -32,7 +32,7 @@ func TestCreateEntitiesFromResult(t *testing.T) {
 
 	evaluationTs := time.Date(2023, 7, 10, 20, 1, 41, 0, time.UTC)
 
-	entity := CreateEntitiesFromResults(resultModel, "test-definition", "test-configuration", "test-image", "storage-id", "config-hash", evaluationTs, 123)
+	entity := CreateEntitiesFromResults(resultModel, "test-definition", "test-configuration", "test-image", "storage-id", "config-hash", evaluationTs, 123, false)
 
 	if entity.Definition != "test-definition" || entity.Configuration != "test-configuration" || entity.StorageId != "storage-id" || entity.CreatedAt.Format("2006-01-02T15:04:05.000Z") != "2023-07-10T20:01:41.000Z" {
 		t.Errorf("metadata not set correctly")
@@ -43,7 +43,7 @@ func TestCreateEntitiesFromResult(t *testing.T) {
 	}
 }
 
-func TestNoDataSetsRetraction(t *testing.T) {
+func TestNoDataSetsRetractionWhenPreviousResultsExit(t *testing.T) {
 	result := `[{:name "CVE-2023-2650", :details {:purl "pkg:alpine/openssl@3.1.0-r4?os_name=alpine&os_version=3.18", :cve "CVE-2023-2650", :severity "HIGH", :fixed-by "3.1.1-r0"} }]`
 
 	resultModel := []GoalEvaluationQueryResult{}
@@ -52,9 +52,25 @@ func TestNoDataSetsRetraction(t *testing.T) {
 
 	evaluationTs := time.Date(2023, 7, 10, 20, 1, 41, 0, time.UTC)
 
-	entity := CreateEntitiesFromResults(resultModel, "test-definition", "test-configuration", "test-image", "no-data", "config-hash", evaluationTs, 123)
+	entity := CreateEntitiesFromResults(resultModel, "test-definition", "test-configuration", "test-image", "no-data", "config-hash", evaluationTs, 123, true)
 
 	if !entity.StorageId.(RetractionEntity).Retract || !entity.DeviationCount.(RetractionEntity).Retract {
+		t.Errorf("metadata not set correctly")
+	}
+}
+
+func TestNoDataNilsOutDeviationCountWhenNoPreviousResultsExist(t *testing.T) {
+	result := `[{:name "CVE-2023-2650", :details {:purl "pkg:alpine/openssl@3.1.0-r4?os_name=alpine&os_version=3.18", :cve "CVE-2023-2650", :severity "HIGH", :fixed-by "3.1.1-r0"} }]`
+
+	resultModel := []GoalEvaluationQueryResult{}
+
+	edn.Unmarshal([]byte(result), &resultModel)
+
+	evaluationTs := time.Date(2023, 7, 10, 20, 1, 41, 0, time.UTC)
+
+	entity := CreateEntitiesFromResults(resultModel, "test-definition", "test-configuration", "test-image", "no-data", "config-hash", evaluationTs, 123, false)
+
+	if entity.StorageId != nil || entity.DeviationCount != nil {
 		t.Errorf("metadata not set correctly")
 	}
 }


### PR DESCRIPTION
cherry-pick of atomist-skills/goal-evaluation-skill#221

> If we do not yet have results for a specific policy, attempting to retract fields within its result entity fails.