### PR TITLE
fix subscription data source ix

### DIFF
--- a/policy/data/subscription.go
+++ b/policy/data/subscription.go
@@ -2,8 +2,6 @@ package data
 
 import (
 	"context"
-	"fmt"
-
 	"olympos.io/encoding/edn"
 )
 
@@ -28,8 +26,8 @@ func (ds SubscriptionDataSource) Query(_ context.Context, queryName string, _ st
 		return nil, nil
 	}
 
-	if ix >= len(ds.subscriptionResults) {
-		return nil, fmt.Errorf("can't get subscription query %s (index %d) from result length %d", queryName, ix, len(ds.subscriptionResults))
+	if len(ds.subscriptionResults) == 0 || ix >= len(ds.subscriptionResults[0]) {
+		return nil, nil
 	}
 
 	err := edn.Unmarshal(ds.subscriptionResults[0][ix], output)


### PR DESCRIPTION
There was an index mismatch here which would cause unnecessary failures when using a non-zero index.

I have an in-progress change still about switching this to use named keys, but until then this index mismatch blocks atomist-skills/policy-base-images#45