### PR TITLE
do not use async data source when metadata is too large

### DIFF
--- a/policy/data/gql_async.go
+++ b/policy/data/gql_async.go
@@ -94,6 +94,12 @@ func (ds AsyncDataSource) Query(ctx context.Context, queryName string, query str
 		return nil, fmt.Errorf("failed to marshal metadata: %w", err)
 	}
 
+	metadata64 := b64.StdEncoding.EncodeToString(metadataEdn)
+	if len(metadata64) > 1024 {
+		ds.log.Warnf("Skipping async data source usage for query %s due to metadata overflow!", queryName)
+		return nil, nil
+	}
+
 	request := AsyncQueryRequest{
 		Name: AsyncQueryName,
 		Body: AsyncQueryBody{


### PR DESCRIPTION
approved-base-images executions are failing due to metadata being too large after atomist-skills/policy-base-images@656f77ee33a48dddc61aa2e4aaa88c0baa3d8a29

This addition enables the async data source to independently refuse a query if the metadata is too large, preserving the async query usage when capable, but falling back to sync in this case.