### PR TITLE
enable logging for sync request

### DIFF
--- a/log.go
+++ b/log.go
@@ -110,7 +110,7 @@ func createLogger(ctx context.Context, event EventIncoming) Logger {
 
 	var doLog = func(msg string, level edn.Keyword) {
 		// Don't send logs when evaluating policies locally
-		if os.Getenv("SCOUT_LOCAL_POLICY_EVALUATION") == "true" || event.Type == "sync-request" {
+		if os.Getenv("SCOUT_LOCAL_POLICY_EVALUATION") == "true" {
 			return
 		}
 		bs, err := edn.MarshalPPrint(internal.LogBody{Logs: []internal.LogEntry{{


### PR DESCRIPTION
now that sync request evaluations happen in the skills platform and not locally, we should re-enable full logging to have visibility into failures