### PR TITLE
remove library/ from base image mock

### DIFF
--- a/policy/policy_handler/mocks/base_image.go
+++ b/policy/policy_handler/mocks/base_image.go
@@ -48,7 +48,7 @@ func parseFromReference(ref string) *SubscriptionRepository {
 	case 1:
 		return &SubscriptionRepository{
 			Host:       "hub.docker.com",
-			Repository: fmt.Sprintf("library/%s", parts[0]),
+			Repository: fmt.Sprintf("%s", parts[0]),
 		}
 
 	case 2:

--- a/policy/policy_handler/mocks/base_image_test.go
+++ b/policy/policy_handler/mocks/base_image_test.go
@@ -24,7 +24,7 @@ func Test_parseFromReference(t *testing.T) {
 			args: args{ref: "nginx"},
 			want: &SubscriptionRepository{
 				Host:       "hub.docker.com",
-				Repository: "library/nginx",
+				Repository: "nginx",
 			},
 		},
 		{


### PR DESCRIPTION
We should not add this library/ prefix to DOI base images in the GetBaseImagesMock. Datomic does not have this prefix, which was causing mismatches in approved-base-image's supportedTags query on sync request evaluations.