### PR TITLE
mock base image distro

### DIFF
--- a/policy/policy_handler/mocks/base_image.go
+++ b/policy/policy_handler/mocks/base_image.go
@@ -17,8 +17,14 @@ type BaseImageQueryResult struct {
 	FromTag       *string                 `edn:"docker.image/from-tag"`
 }
 
+type SubscriptionDistro struct {
+	Name    string `edn:"os.distro/name"`
+	Version string `edn:"os.distro/version"`
+}
+
 type SubscriptionImage struct {
-	Digest string `edn:"docker.image/digest"`
+	Digest string              `edn:"docker.image/digest"`
+	Distro *SubscriptionDistro `edn:"docker.image/distro"`
 }
 
 type SubscriptionRepository struct {
@@ -30,6 +36,7 @@ func MockBaseImage(sb *types.SBOM) BaseImageQueryResult {
 	return BaseImageQueryResult{
 		FromReference: &SubscriptionImage{
 			Digest: sb.Source.Provenance.BaseImage.Digest,
+			Distro: convertDistro(sb.Source.Image.Distro),
 		},
 		FromRepo: parseFromReference(sb.Source.Provenance.BaseImage.Name),
 		FromTag:  &sb.Source.Provenance.BaseImage.Tag,
@@ -63,4 +70,15 @@ func parseFromReference(ref string) *SubscriptionRepository {
 			Repository: fmt.Sprintf("%s/%s", parts[1], parts[2]),
 		}
 	}
+}
+
+func convertDistro(sbDistro types.Distro) *SubscriptionDistro {
+	if sbDistro.OsName != "" && sbDistro.OsVersion != "" {
+		return &SubscriptionDistro{
+			Name:    sbDistro.OsName,
+			Version: sbDistro.OsVersion,
+		}
+	}
+
+	return nil
 }

--- a/policy/policy_handler/mocks/base_image_test.go
+++ b/policy/policy_handler/mocks/base_image_test.go
@@ -1,6 +1,8 @@
 package mocks
 
 import (
+	"github.com/atomist-skills/go-skill/policy/types"
+	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 )
@@ -49,6 +51,39 @@ func Test_parseFromReference(t *testing.T) {
 			if got := parseFromReference(tt.args.ref); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("parseFromReference() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func Test_convertDistro(t *testing.T) {
+	testCases := []struct {
+		name     string
+		arg      types.Distro
+		expected *SubscriptionDistro
+	}{
+		{
+			name:     "Returns nil when distro information is not present",
+			arg:      types.Distro{},
+			expected: nil,
+		},
+		{
+			name: "Correctly converts distro to subscription form when available",
+			arg: types.Distro{
+				OsName:    "debian",
+				OsVersion: "10",
+				OsDistro:  "buster",
+			},
+			expected: &SubscriptionDistro{
+				Name:    "debian",
+				Version: "10",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := convertDistro(tc.arg)
+			assert.Equal(t, tc.expected, actual, "convertDistro() = %+v, want %+v", actual, tc.expected)
 		})
 	}
 }


### PR DESCRIPTION
Although we did all the work to get the distro in scout-cli-plugin, we never mocked it! This adds it to MockBaseImage via the SBOM for use in approved-base-images.