### PR TITLE
make it possible to get the httphandler from a policy skill

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @atomist-skills/ssc-data-policy
+* @atomist-skills/ssc-dev-features

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+# Description
+<sup>*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*</sup>
+
+## Related PRs
+
+None


### PR DESCRIPTION
Add function for getting httpHandler from a policy skill so it can be hosted elsewhere.