### PR TITLE
mock image-details-by-digest for no-stale-base-images

### DIFF
--- a/policy/policy_handler/mocks/base_image_details.go
+++ b/policy/policy_handler/mocks/base_image_details.go
@@ -1,0 +1,116 @@
+package mocks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/atomist-skills/go-skill"
+	"github.com/atomist-skills/go-skill/policy/data"
+	"github.com/atomist-skills/go-skill/policy/types"
+)
+
+const (
+	ImageDetailsQueryName = "image-details-by-digest"
+
+	baseImagesByDigestQuery = `
+	query ($context: Context!, $digest: String!) {
+		baseImagesByDigest(context: $context, digest: $digest) {
+		  images {
+			digest
+			tags {
+			  current
+			  name
+			}
+			repository {
+				hostName
+				repoName
+			}
+		  }
+		}
+	}`
+)
+
+type (
+	GqlImagePlatform struct {
+		Architecture string `json:"architecture"`
+		Os           string `json:"os"`
+		Variant      string `json:"variant,omitempty"`
+	}
+
+	Repository struct {
+		HostName string `json:"hostName" edn:"hostName"`
+		RepoName string `json:"repoName" edn:"repoName"`
+	}
+
+	Tag struct {
+		Name    string `json:"name" edn:"name"`
+		Current bool   `json:"current" edn:"current"`
+	}
+
+	BaseImage struct {
+		Digest     string     `json:"digest" edn:"digest"`
+		Repository Repository `json:"repository" edn:"repository"`
+		Tags       []Tag      `json:"tags" edn:"tags"`
+	}
+
+	ImageDetailsByDigest struct {
+		Digest       string     `json:"digest" edn:"digest"`
+		BaseImage    *BaseImage `json:"baseImage" edn:"baseImage"`
+		BaseImageTag *Tag       `json:"baseImageTag" edn:"baseImageTag"`
+	}
+
+	ImageDetailsByDigestResponse struct {
+		ImageDetailsByDigest *ImageDetailsByDigest `json:"imageDetailsByDigest" edn:"imageDetailsByDigest"`
+	}
+
+	BaseImagesByDigest struct {
+		Images []BaseImage `json:"images" edn:"images"`
+	}
+
+	BaseImagesByDigestResponse struct {
+		BaseImagesByDigest *BaseImagesByDigest `json:"baseImagesByDigest" edn:"baseImagesByDigest"`
+	}
+)
+
+func MockBaseImageDetails(ctx context.Context, req skill.RequestContext, sb *types.SBOM) (ImageDetailsByDigestResponse, error) {
+	ds, err := data.NewSyncGraphqlDataSource(ctx, req)
+	if err != nil {
+		return ImageDetailsByDigestResponse{}, err
+	}
+
+	baseImageDigest := sb.Source.Provenance.BaseImage.Digest
+
+	var queryResponse BaseImagesByDigestResponse
+
+	queryVariables := map[string]interface{}{"digest": baseImageDigest}
+	_, err = ds.Query(ctx, "base-images-by-digest", baseImagesByDigestQuery, queryVariables, &queryResponse)
+	if err != nil {
+		return ImageDetailsByDigestResponse{}, err
+	}
+
+	if len(queryResponse.BaseImagesByDigest.Images) == 0 {
+		return ImageDetailsByDigestResponse{}, fmt.Errorf("no base images found for digest %s", baseImageDigest)
+	}
+
+	baseImage := queryResponse.BaseImagesByDigest.Images[0]
+	baseImageTag := findBaseImageTag(baseImage, sb.Source.Provenance.BaseImage.Tag)
+
+	mockResponse := ImageDetailsByDigestResponse{
+		ImageDetailsByDigest: &ImageDetailsByDigest{
+			Digest:       sb.Source.Image.Digest,
+			BaseImage:    &baseImage,
+			BaseImageTag: baseImageTag,
+		},
+	}
+
+	return mockResponse, nil
+}
+
+func findBaseImageTag(baseImage BaseImage, tag string) *Tag {
+	for _, t := range baseImage.Tags {
+		if t.Name == tag {
+			return &t
+		}
+	}
+	return nil
+}

--- a/policy/policy_handler/mocks/base_image_details.go
+++ b/policy/policy_handler/mocks/base_image_details.go
@@ -12,6 +12,8 @@ import (
 const (
 	ImageDetailsQueryName = "image-details-by-digest"
 
+	baseImagesByDigestQueryName = "base-images-by-digest"
+
 	baseImagesByDigestQuery = `
 	query ($context: Context!, $digest: String!) {
 		baseImagesByDigest(context: $context, digest: $digest) {
@@ -78,12 +80,21 @@ func MockBaseImageDetails(ctx context.Context, req skill.RequestContext, sb *typ
 		return ImageDetailsByDigestResponse{}, err
 	}
 
+	return mockBaseImageDetails(ctx, req, sb, ds)
+}
+
+func mockBaseImageDetails(ctx context.Context, req skill.RequestContext, sb *types.SBOM, ds data.DataSource) (ImageDetailsByDigestResponse, error) {
+	ds, err := data.NewSyncGraphqlDataSource(ctx, req)
+	if err != nil {
+		return ImageDetailsByDigestResponse{}, err
+	}
+
 	baseImageDigest := sb.Source.Provenance.BaseImage.Digest
 
 	var queryResponse BaseImagesByDigestResponse
 
 	queryVariables := map[string]interface{}{"digest": baseImageDigest}
-	_, err = ds.Query(ctx, "base-images-by-digest", baseImagesByDigestQuery, queryVariables, &queryResponse)
+	_, err = ds.Query(ctx, baseImagesByDigestQueryName, baseImagesByDigestQuery, queryVariables, &queryResponse)
 	if err != nil {
 		return ImageDetailsByDigestResponse{}, err
 	}

--- a/policy/policy_handler/mocks/base_image_details.test.go
+++ b/policy/policy_handler/mocks/base_image_details.test.go
@@ -1,0 +1,96 @@
+package mocks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/atomist-skills/go-skill"
+	"github.com/atomist-skills/go-skill/policy/data"
+	"github.com/atomist-skills/go-skill/policy/types"
+	"github.com/stretchr/testify/assert"
+)
+
+type MockDs struct {
+	t *testing.T
+}
+
+func (ds MockDs) Query(ctx context.Context, queryName string, query string, variables map[string]interface{}, output interface{}) (*data.QueryResponse, error) {
+	assert.Equal(ds.t, queryName, baseImagesByDigestQueryName)
+	assert.Equal(ds.t, query, baseImagesByDigestQuery)
+
+	r := output.(*BaseImagesByDigestResponse)
+	r.BaseImagesByDigest.Images = []BaseImage{
+		BaseImage{
+			Digest: "sha256:1234",
+			Repository: Repository{
+				HostName: "registry.com",
+				RepoName: "namespace/repository",
+			},
+			Tags: []Tag{
+				Tag{
+					Name:    "latest",
+					Current: true,
+				},
+				Tag{
+					Name:    "1.0",
+					Current: false,
+				},
+			},
+		},
+	}
+
+	return &data.QueryResponse{}, nil
+}
+
+func Test_mockBaseImageDetails(t *testing.T) {
+	sbom := &types.SBOM{
+		Source: types.Source{
+			Image: &types.ImageSource{
+				Digest: "sha256:9999",
+			},
+			Provenance: &types.Provenance{
+				BaseImage: &types.ProvenanceBaseImage{
+					Digest: "sha256:1234",
+
+					Tag: "1.0",
+				},
+			},
+		},
+	}
+
+	logger := skill.Logger{
+		Debug:  func(msg string) {},
+		Debugf: func(format string, a ...any) {},
+	}
+	actual, err := mockBaseImageDetails(context.TODO(), skill.RequestContext{Log: logger}, sbom, MockDs{t})
+	assert.NoError(t, err)
+
+	expected := ImageDetailsByDigestResponse{
+		ImageDetailsByDigest: &ImageDetailsByDigest{
+			Digest: "sha256:9999",
+			BaseImage: &BaseImage{
+				Digest: "sha256:1234",
+				Repository: Repository{
+					HostName: "registry.com",
+					RepoName: "namespace/repository",
+				},
+				Tags: []Tag{
+					Tag{
+						Name:    "latest",
+						Current: true,
+					},
+					Tag{
+						Name:    "1.0",
+						Current: false,
+					},
+				},
+			},
+			BaseImageTag: &Tag{
+				Name:    "1.0",
+				Current: false,
+			},
+		},
+	}
+
+	assert.Equal(t, expected, actual)
+}

--- a/policy/policy_handler/mocks/builder.go
+++ b/policy/policy_handler/mocks/builder.go
@@ -59,6 +59,14 @@ func BuildLocalEvalMocks(ctx context.Context, req skill.RequestContext, sb *type
 		if err != nil {
 			return m, fmt.Errorf("failed to marshal base image mock: %w", err)
 		}
+		imageDetailsMock, err := MockBaseImageDetails(ctx, req, sb)
+		if err != nil {
+			return m, fmt.Errorf("failed to create image details mock: %w", err)
+		}
+		m[ImageDetailsQueryName], err = edn.Marshal(imageDetailsMock)
+		if err != nil {
+			return m, fmt.Errorf("failed to marshal image details mock: %w", err)
+		}
 	}
 
 	return m, nil


### PR DESCRIPTION
# Description
Need to mock image-details-by-digest for the no-stale-base-images policy.

This is just a temporary fix, a proper refactoring will come after.

## Related PRs

None