### PR TITLE
use provenance mode flag instead of source map

### DIFF
--- a/policy/goals/types.go
+++ b/policy/goals/types.go
@@ -87,8 +87,12 @@ type (
 		Predicates    []Predicate `edn:"intoto.predicate/_attestation"`
 	}
 
+	BuildKitProvenanceMode struct {
+		Ident edn.Keyword `edn:"db/ident"`
+	}
+
 	Predicate struct {
-		StartLine *int `edn:"slsa.provenance.from/start-line"` // if field is present then provenance is max-mode
+		ProvenanceMode *BuildKitProvenanceMode `edn:"buildkit.provenance/mode,omitempty"`
 	}
 
 	ImageSubscriptionQueryResult struct {

--- a/policy/policy_handler/subscription.go
+++ b/policy/policy_handler/subscription.go
@@ -81,13 +81,13 @@ func createSbomFromSubscriptionResult(subscriptionResult []map[edn.Keyword]edn.R
 			attestations = append(attestations, env)
 
 			for _, predicate := range attestation.Predicates {
-				if predicate.ProvenanceMode == nil {
+				if predicate.ProvenanceMode != nil {
 					var mode string
-					if predicate.ProvenanceMode.Ident == edn.Keyword("buildkit.provenance.mode/MAX") {
-						mode = types.BuildKitMaxMode
-					}
 
-					if predicate.ProvenanceMode.Ident == edn.Keyword("buildkit.provenance.mode/MIN") {
+					switch predicate.ProvenanceMode.Ident {
+					case edn.Keyword("buildkit.provenance.mode/MAX"):
+						mode = types.BuildKitMaxMode
+					case edn.Keyword("buildkit.provenance.mode/MIN"):
 						mode = types.BuildKitMinMode
 					}
 

--- a/policy/types/types.go
+++ b/policy/types/types.go
@@ -6,6 +6,11 @@ import (
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
 
+const (
+	BuildKitMaxMode = "buildkit_max_mode"
+	BuildKitMinMode = "buildkit_min_mode"
+)
+
 type SBOM struct {
 	Source          Source                  `json:"source"`
 	Attestations    []dsse.Envelope         `json:"attestations"`
@@ -110,6 +115,7 @@ type Provenance struct {
 	VCS       *VCS                 `json:"vcs,omitempty"`
 	BaseImage *ProvenanceBaseImage `json:"base_image,omitempty"`
 	Stream    *Stream              `json:"stream,omitempty"`
+	Mode      string               `json:"mode,omitempty"`
 }
 
 type SourceMap struct {


### PR DESCRIPTION
# Description
We now have a shiny new provenance mode flag that we should use instead of messing around with source maps.

## Related PRs

https://github.com/docker/scout-cli-plugin/pull/469