### PR TITLE
allow for passing a correlation id and having no organization

### DIFF
--- a/policy/data/gql_sync.go
+++ b/policy/data/gql_sync.go
@@ -22,6 +22,10 @@ func NewSyncGraphqlDataSourceFromSkillRequest(ctx context.Context, req skill.Req
 }
 
 func NewSyncGraphqlDataSource(ctx context.Context, token string, url string, logger skill.Logger) (SyncGraphqlDataSource, error) {
+	return NewSyncGraphqlDataSourceWithCorrelationId(ctx, token, url, logger, nil)
+}
+
+func NewSyncGraphqlDataSourceWithCorrelationId(ctx context.Context, token string, url string, logger skill.Logger, correlationId *string) (SyncGraphqlDataSource, error) {
 	httpClient := oauth2.NewClient(ctx, oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token, TokenType: "Bearer"},
 	))
@@ -31,6 +35,10 @@ func NewSyncGraphqlDataSource(ctx context.Context, token string, url string, log
 		graphqlClient: graphql.NewClient(url, httpClient).
 			WithRequestModifier(func(r *http.Request) {
 				r.Header.Add("Accept", "application/json")
+
+				if correlationId != nil {
+					r.Header.Add("X-Atomist-Correlation-Id", *correlationId)
+				}
 			}),
 		logger: logger,
 	}, nil

--- a/policy/data/source.go
+++ b/policy/data/source.go
@@ -15,8 +15,15 @@ type DataSource interface {
 }
 
 func GqlContext(ctx goals.GoalEvaluationContext) map[string]interface{} {
-	return map[string]interface{}{
-		"teamId":       ctx.TeamId,
-		"organization": ctx.Organization,
+	result := map[string]interface{}{}
+
+	if ctx.TeamId != "" {
+		result["teamId"] = ctx.TeamId
 	}
+
+	if ctx.Organization != "" {
+		result["organization"] = ctx.Organization
+	}
+
+	return result
 }


### PR DESCRIPTION
# Description
`poliwrath` would like to pass a correlation id into GQL queries, and also be able to operate purely against public data, with no organizational context.

## Related PRs

None