### PR TITLE
populate platform variant on sbom

### DIFF
--- a/policy/goals/types.go
+++ b/policy/goals/types.go
@@ -80,6 +80,7 @@ type (
 	ImagePlatform struct {
 		Architecture string `edn:"docker.platform/architecture" json:"architecture"`
 		Os           string `edn:"docker.platform/os" json:"os"`
+		Variant      string `edn:"docker.platform/variant" json:"variant"`
 	}
 
 	Attestation struct {

--- a/policy/policy_handler/subscription.go
+++ b/policy/policy_handler/subscription.go
@@ -117,6 +117,7 @@ func createSbomFromSubscriptionResult(subscriptionResult []map[edn.Keyword]edn.R
 		sbom.Source.Image.Platform = types.Platform{
 			Architecture: image.ImagePlatforms[0].Architecture,
 			Os:           image.ImagePlatforms[0].Os,
+			Variant:      image.ImagePlatforms[0].Variant,
 		}
 	}
 


### PR DESCRIPTION
# Description
populate the platform variant on the sbom when it is in the subscription result

## Related PRs

None