### PR TITLE
pass basis-t to gql queries when running from a subscription

### DIFF
--- a/policy/data/gql_async.go
+++ b/policy/data/gql_async.go
@@ -19,15 +19,16 @@ import (
 const AsyncQueryName = "async-query"
 
 type (
-	AsyncQueryBody struct {
+	GraphQLQueryBody struct {
 		Query     string                      `edn:"query"`
 		Variables map[edn.Keyword]interface{} `edn:"variables"`
+		BasisT    *int64                      `edn:"basis-t,omitempty"`
 	}
 
 	AsyncQueryRequest struct {
-		Name     string         `edn:"name"`
-		Body     AsyncQueryBody `edn:"body"`
-		Metadata string         `edn:"metadata"`
+		Name     string           `edn:"name"`
+		Body     GraphQLQueryBody `edn:"body"`
+		Metadata string           `edn:"metadata"`
 	}
 
 	AsyncQueryResponse struct {
@@ -102,9 +103,10 @@ func (ds AsyncDataSource) Query(ctx context.Context, queryName string, query str
 
 	request := AsyncQueryRequest{
 		Name: AsyncQueryName,
-		Body: AsyncQueryBody{
+		Body: GraphQLQueryBody{
 			Query:     query,
 			Variables: ednVariables,
+			BasisT:    &ds.evaluationMetadata.SubscriptionBasisT,
 		},
 		Metadata: metadata64,
 	}

--- a/policy/data/gql_sync.go
+++ b/policy/data/gql_sync.go
@@ -1,47 +1,64 @@
 package data
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"net/http"
 
 	"golang.org/x/oauth2"
+	"olympos.io/encoding/edn"
 
 	"github.com/hasura/go-graphql-client"
 
 	"github.com/atomist-skills/go-skill"
+	"github.com/atomist-skills/go-skill/policy/goals"
 )
 
 type SyncGraphqlDataSource struct {
 	url           string
-	graphqlClient *graphql.Client
+	httpClient    http.Client
 	logger        skill.Logger
+	correlationId *string
+	basisT        *int64
 }
 
-func NewSyncGraphqlDataSourceFromSkillRequest(ctx context.Context, req skill.RequestContext) (SyncGraphqlDataSource, error) {
+func NewSyncGraphqlDataSourceFromSkillRequest(ctx context.Context, req skill.RequestContext, evalMeta goals.EvaluationMetadata) (SyncGraphqlDataSource, error) {
 	return NewSyncGraphqlDataSource(ctx, req.Event.Token, req.Event.Urls.Graphql, req.Log)
 }
 
 func NewSyncGraphqlDataSource(ctx context.Context, token string, url string, logger skill.Logger) (SyncGraphqlDataSource, error) {
-	return NewSyncGraphqlDataSourceWithCorrelationId(ctx, token, url, logger, nil)
-}
-
-func NewSyncGraphqlDataSourceWithCorrelationId(ctx context.Context, token string, url string, logger skill.Logger, correlationId *string) (SyncGraphqlDataSource, error) {
 	httpClient := oauth2.NewClient(ctx, oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token, TokenType: "Bearer"},
 	))
 
 	return SyncGraphqlDataSource{
-		url: url,
-		graphqlClient: graphql.NewClient(url, httpClient).
-			WithRequestModifier(func(r *http.Request) {
-				r.Header.Add("Accept", "application/json")
-
-				if correlationId != nil {
-					r.Header.Add("X-Atomist-Correlation-Id", *correlationId)
-				}
-			}),
-		logger: logger,
+		url:        url,
+		httpClient: *httpClient,
+		logger:     logger,
 	}, nil
+}
+
+func (ds SyncGraphqlDataSource) WithCorrelationId(correlationId string) SyncGraphqlDataSource {
+	return SyncGraphqlDataSource{
+		url:           ds.url,
+		httpClient:    ds.httpClient,
+		correlationId: &correlationId,
+		basisT:        ds.basisT,
+		logger:        ds.logger,
+	}
+}
+
+func (ds SyncGraphqlDataSource) WithBasisT(basisT int64) SyncGraphqlDataSource {
+	return SyncGraphqlDataSource{
+		url:           ds.url,
+		httpClient:    ds.httpClient,
+		correlationId: ds.correlationId,
+		logger:        ds.logger,
+		basisT:        &basisT,
+	}
 }
 
 func (ds SyncGraphqlDataSource) Query(ctx context.Context, queryName string, query string, variables map[string]interface{}, output interface{}) (*QueryResponse, error) {
@@ -51,7 +68,12 @@ func (ds SyncGraphqlDataSource) Query(ctx context.Context, queryName string, que
 	log.Infof("Executing query %s: %s", queryName, query)
 	log.Infof("Query variables: %v", variables)
 
-	res, err := ds.graphqlClient.ExecRaw(ctx, query, variables)
+	ednVariables := map[edn.Keyword]interface{}{}
+	for k, v := range variables {
+		ednVariables[edn.Keyword(k)] = v
+	}
+
+	res, err := ds.request(ctx, query, ednVariables)
 	if err != nil {
 		return nil, err
 	}
@@ -64,4 +86,72 @@ func (ds SyncGraphqlDataSource) Query(ctx context.Context, queryName string, que
 	}
 
 	return &QueryResponse{}, nil
+}
+
+func (ds SyncGraphqlDataSource) request(ctx context.Context, query string, variables map[edn.Keyword]interface{}) ([]byte, error) {
+	in := GraphQLQueryBody{
+		Query:     query,
+		Variables: variables,
+		BasisT:    ds.basisT,
+	}
+	var buf bytes.Buffer
+	err := json.NewEncoder(&buf).Encode(in)
+	if err != nil {
+		return nil, fmt.Errorf("problem encoding request: %w", err)
+	}
+
+	reqReader := bytes.NewReader(buf.Bytes())
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, ds.url, reqReader)
+	if err != nil {
+		e := fmt.Errorf("problem encoding request: %w", err)
+
+		return nil, e
+	}
+	request.Header.Add("Content-Type", "application/edn")
+
+	request.Header.Add("Accept", "application/json")
+
+	if ds.correlationId != nil {
+		request.Header.Add("X-Atomist-Correlation-Id", *ds.correlationId)
+	}
+
+	resp, err := ds.httpClient.Do(request)
+
+	if err != nil {
+		e := fmt.Errorf("problem making request: %w", err)
+		return nil, e
+	}
+	defer resp.Body.Close()
+
+	r := resp.Body
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := ioutil.ReadAll(resp.Body)
+		err := fmt.Errorf("%v; body: %q", resp.Status, body)
+
+		return nil, err
+	}
+
+	var out struct {
+		Data   *json.RawMessage
+		Errors graphql.Errors
+	}
+
+	err = json.NewDecoder(r).Decode(&out)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var rawData []byte
+	if out.Data != nil && len(*out.Data) > 0 {
+		rawData = []byte(*out.Data)
+	}
+
+	if len(out.Errors) > 0 {
+
+		return rawData, out.Errors
+	}
+
+	return rawData, nil
 }

--- a/policy/goals/types.go
+++ b/policy/goals/types.go
@@ -109,6 +109,7 @@ type (
 	EvaluationMetadata struct {
 		SubscriptionResult []map[edn.Keyword]edn.RawMessage `edn:"subscription-result"`
 		SubscriptionTx     int64                            `edn:"subscription-tx"`
+		SubscriptionBasisT int64                            `edn:"subscription-basis-t"`
 	}
 
 	GoalEvaluator interface {

--- a/policy/policy_handler/subscription.go
+++ b/policy/policy_handler/subscription.go
@@ -31,6 +31,7 @@ func getSubscriptionData(_ context.Context, req skill.RequestContext) (*goals.Ev
 	evalMeta := &goals.EvaluationMetadata{
 		SubscriptionResult: req.Event.Context.Subscription.GetResultInMapForm(),
 		SubscriptionTx:     req.Event.Context.Subscription.Metadata.Tx,
+		SubscriptionBasisT: req.Event.Context.Subscription.Metadata.AfterBasisT,
 	}
 
 	sbom, err := createSbomFromSubscriptionResult(evalMeta.SubscriptionResult, req)

--- a/policy/policy_handler/sync.go
+++ b/policy/policy_handler/sync.go
@@ -17,7 +17,7 @@ func WithSyncQuery() Opt {
 }
 
 func getSyncDataSources(ctx context.Context, req skill.RequestContext, evalMeta goals.EvaluationMetadata) ([]data.DataSource, error) {
-	gqlDs, err := data.NewSyncGraphqlDataSourceFromSkillRequest(ctx, req)
+	gqlDs, err := data.NewSyncGraphqlDataSourceFromSkillRequest(ctx, req, evalMeta)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create data source: %w", err)
 	}


### PR DESCRIPTION
# Description
GQL query endpoints now support passing `basis-t` to specify the minimum version of the DB that the query should be run against. When triggered by a subscription, policy skills should specify that in the GQL query request.

## Related PRs

None