### PR TITLE
actually set basis-t from the eval context

### DIFF
--- a/policy/data/gql_sync.go
+++ b/policy/data/gql_sync.go
@@ -25,11 +25,11 @@ type SyncGraphqlDataSource struct {
 	basisT        *int64
 }
 
-func NewSyncGraphqlDataSourceFromSkillRequest(ctx context.Context, req skill.RequestContext, evalMeta goals.EvaluationMetadata) (SyncGraphqlDataSource, error) {
-	return NewSyncGraphqlDataSource(ctx, req.Event.Token, req.Event.Urls.Graphql, req.Log)
+func NewSyncGraphqlDataSourceFromSkillRequest(ctx context.Context, req skill.RequestContext, evalMeta goals.EvaluationMetadata) SyncGraphqlDataSource {
+	return NewSyncGraphqlDataSource(ctx, req.Event.Token, req.Event.Urls.Graphql, req.Log).WithBasisT(evalMeta.SubscriptionBasisT)
 }
 
-func NewSyncGraphqlDataSource(ctx context.Context, token string, url string, logger skill.Logger) (SyncGraphqlDataSource, error) {
+func NewSyncGraphqlDataSource(ctx context.Context, token string, url string, logger skill.Logger) SyncGraphqlDataSource {
 	httpClient := oauth2.NewClient(ctx, oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token, TokenType: "Bearer"},
 	))
@@ -38,7 +38,7 @@ func NewSyncGraphqlDataSource(ctx context.Context, token string, url string, log
 		url:        url,
 		httpClient: *httpClient,
 		logger:     logger,
-	}, nil
+	}
 }
 
 func (ds SyncGraphqlDataSource) WithCorrelationId(correlationId string) SyncGraphqlDataSource {

--- a/policy/policy_handler/sync.go
+++ b/policy/policy_handler/sync.go
@@ -2,7 +2,6 @@ package policy_handler
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/atomist-skills/go-skill/policy/goals"
 
@@ -17,10 +16,7 @@ func WithSyncQuery() Opt {
 }
 
 func getSyncDataSources(ctx context.Context, req skill.RequestContext, evalMeta goals.EvaluationMetadata) ([]data.DataSource, error) {
-	gqlDs, err := data.NewSyncGraphqlDataSourceFromSkillRequest(ctx, req, evalMeta)
-	if err != nil {
-		return nil, fmt.Errorf("unable to create data source: %w", err)
-	}
+	gqlDs := data.NewSyncGraphqlDataSourceFromSkillRequest(ctx, req, evalMeta)
 
 	return []data.DataSource{
 		gqlDs,


### PR DESCRIPTION
# Description
Set it up beautifully but never actually set `basis-t` from the evaluation context.

## Related PRs

None