### PR TITLE
errors should probably be returned as errors

### DIFF
--- a/http_transact.go
+++ b/http_transact.go
@@ -19,6 +19,7 @@ package skill
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"reflect"
 
@@ -106,7 +107,7 @@ func httpTransact(entities interface{}, orderingKey string, workspace string, ap
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 202 {
-		logger.Warnf("Error transacting entities: %s", resp.Status)
+		return fmt.Errorf("error transacting entities: %s", resp.Status)
 	}
 
 	return nil

--- a/policy/transact/transact.go
+++ b/policy/transact/transact.go
@@ -74,7 +74,6 @@ func TransactPolicyResult(
 	if resultEntity != nil {
 		err = newTransaction().AddEntities(*resultEntity).Transact()
 		if err != nil {
-			evalCtx.Log.Errorf(err.Error())
 			return nil, fmt.Errorf("Failed to transact goal results: %s", err.Error())
 		}
 		evalCtx.Log.Info("Goal results transacted")


### PR DESCRIPTION
# Description
Warning and swallowing the error isn't great. return the error so the caller can decide what to do with it.

## Related PRs

None