### PR TITLE
use shared httpClient and retry status sending failures

### DIFF
--- a/http_transact.go
+++ b/http_transact.go
@@ -80,7 +80,7 @@ func httpTransact(entities interface{}, orderingKey string, workspace string, ap
 		message.CorrelationId = uuid.NewString()
 	}
 
-	client := &http.Client{}
+	client := http.DefaultClient
 
 	logger.Debugf("Transacting entities with correlation id %s:\n%s", message.CorrelationId, string(bs))
 	j, _ := json.MarshalIndent(message, "", "  ")

--- a/test/simulate.go
+++ b/test/simulate.go
@@ -95,7 +95,7 @@ func Simulate(options SimulateOptions, t *testing.T) SimulateResult {
 }
 `, options.Skill.Id, options.Skill.Namespace, options.Skill.Name, options.Skill.Version, schemata, subscriptionName[0:len(subscriptionName)-4], string(subscription), string(configuration), string(txData))
 
-	client := &http.Client{}
+	client := http.DefaultClient
 	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("https://api.atomist.com/datalog/team/%s/simulate", options.WorkspaceId), strings.NewReader(payload))
 	req.Header.Set("Authorization", "Bearer "+options.Token)
 	req.Header.Set("Content-Type", "application/edn")

--- a/transact.go
+++ b/transact.go
@@ -217,7 +217,7 @@ func createMessageSender(ctx context.Context, req RequestContext) messageSender 
 			return err
 		}
 
-		client := &http.Client{}
+		client := http.DefaultClient
 
 		req.Log.Debugf("Transacting entities: %s", string(bs))
 


### PR DESCRIPTION
# Description
Instead of creating new httpClients everywhere, let's share the DefaultClient.

Also add a retry for when sending skill execution status fails.

## Related PRs

None