### PR TITLE
apply vex statements when using public vuln data

### DIFF
--- a/sbom/normalization/normalization.go
+++ b/sbom/normalization/normalization.go
@@ -8,6 +8,7 @@ import (
 	"github.com/anchore/syft/syft/linux"
 	"github.com/atomist-skills/go-skill/internal"
 	"github.com/atomist-skills/go-skill/policy/types"
+	"github.com/openvex/go-vex/pkg/vex"
 )
 
 // NormalizeSBOM creates the canonical representation of our internal PURL model
@@ -91,6 +92,28 @@ func NormalizePURL(pkg string, d *types.Distro) (string, string) {
 		upstreamPurl = purl.String()
 	}
 	return pkgPurl, upstreamPurl
+}
+
+func ContainsPurl(purls []vex.Subcomponent, purl string) bool {
+	p, _ := ToPackageUrl(purl)
+	for _, pu := range purls {
+		np, nsp := NormalizePURL(pu.ID, nil)
+		npp, err := ToPackageUrl(np)
+		if err != nil {
+			continue
+		}
+		if npp.Type == p.Type && npp.Namespace == p.Namespace && npp.Name == p.Name && npp.Version == p.Version {
+			return true
+		}
+		nspp, err := ToPackageUrl(nsp)
+		if err != nil {
+			continue
+		}
+		if nspp.Type == p.Type && nspp.Namespace == p.Namespace && nspp.Name == p.Name && nspp.Version == p.Version {
+			return true
+		}
+	}
+	return false
 }
 
 func ToPackageUrl(url string) (anchorepackageurl.PackageURL, error) {


### PR DESCRIPTION
# Description
If `Vulnerabilities` is provided in the SBOM then we can assume VEX has been applied. And if we are fetching the vulnerabilities alongside the packages from the platform then VEX has been applied. But if we have the packages and are fetching public vulnerabilities, then we need to apply VEX here.

## Related PRs

None