### PR TITLE
Pass digest into `vulnerabilitiesByPackage`

### DIFF
--- a/policy/data/vulnerabilities.go
+++ b/policy/data/vulnerabilities.go
@@ -33,6 +33,7 @@ func (ds *DataSource) GetImageVulnerabilities(ctx context.Context, evalCtx goals
 		r, err := ds.jynxGQLClient.Query(ctx, jynx.VulnerabilitiesByPackageQueryName, jynx.VulnerabilitiesByPackageQuery, map[string]interface{}{
 			"context": query.GqlContext(evalCtx),
 			"purls":   purls,
+			"digest":  imageSbom.Source.Image.Digest,
 		}, &vulnsResponse)
 		if err != nil || r.AsyncRequestMade {
 			return r, nil, nil, err


### PR DESCRIPTION
# Description
Providing the image digest context allows the query to take into account vulnerability exceptions properly.

## Related PRs

None