### PR TITLE
[SDC-1169] parse int32 args correctly

### DIFF
--- a/policy/skills/parse.go
+++ b/policy/skills/parse.go
@@ -47,6 +47,11 @@ func ParseIntArg(arg interface{}) int64 {
 		return parsedArgAsInt64
 	}
 
+	parsedArgAsInt32, ok := arg.(int32)
+	if ok {
+		return int64(parsedArgAsInt32)
+	}
+
 	parsedArgAsFloat, ok := arg.(float64)
 	if ok {
 		return int64(parsedArgAsFloat)

--- a/policy/skills/parse_test.go
+++ b/policy/skills/parse_test.go
@@ -86,6 +86,16 @@ func TestParseIntArgs(t *testing.T) {
 			arg:  int64(30),
 			want: 30,
 		},
+		{
+			name: "Parse int32 arg",
+			arg:  int32(30),
+			want: 30,
+		},
+		{
+			name: "Parse float64 arg",
+			arg:  float64(30),
+			want: 30,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Description
parse int32 args correctly so that consumers don't have to worry about what arg type they pass in

## Related PRs

None