### PR TITLE
add proxy-client back in

### DIFF
--- a/policy/data/proxy/client.go
+++ b/policy/data/proxy/client.go
@@ -1,0 +1,12 @@
+package proxy
+
+import (
+	"context"
+
+	"github.com/atomist-skills/go-skill/policy/goals"
+	"github.com/atomist-skills/go-skill/policy/types"
+)
+
+type ProxyClient interface {
+	Evaluate(ctx context.Context, organization, teamId, url string, sbom *types.SBOM, args map[string]interface{}) (goals.EvaluationResult, error)
+}

--- a/policy/data/source.go
+++ b/policy/data/source.go
@@ -3,6 +3,7 @@ package data
 import (
 	"context"
 
+	"github.com/atomist-skills/go-skill/policy/data/proxy"
 	"github.com/atomist-skills/go-skill/policy/data/query"
 	"github.com/atomist-skills/go-skill/policy/goals"
 	"github.com/atomist-skills/go-skill/policy/types"
@@ -10,6 +11,7 @@ import (
 
 type DataSource interface {
 	GetQueryClient() query.QueryClient
+	GetProxyClient() proxy.ProxyClient
 
 	GetImageVulnerabilities(ctx context.Context, evalCtx goals.GoalEvaluationContext, imageSbom types.SBOM) (*query.QueryResponse, []types.Package, map[string][]types.Vulnerability, error)
 }

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -16,4 +16,5 @@ type Policy struct {
 	WithLocal            bool
 	WithAsync            bool
 	WithSyncQuery        bool
+	WithProxy            bool
 }


### PR DESCRIPTION
# Description
I had hoped to remove this from go-skill and handle it purely in poliwrath, but it is in fact just simpler to maintain this interface for now and make this change later.

## Related PRs

None