### PR TITLE
Windows 10 and above support colours now.

### DIFF
--- a/log.go
+++ b/log.go
@@ -61,7 +61,7 @@ func init() {
 		Log.SetFormatter(&logrus.TextFormatter{
 			DisableTimestamp: true,
 			PadLevelText:     true,
-			ForceColors:      runtime.GOOS != "windows",
+			ForceColors:      true,
 		})
 	}
 


### PR DESCRIPTION
# Description
Windows 10 and above support colours now, and logrus CLI output is awful if you don't force colours.

## Related PRs

None